### PR TITLE
Added extra fields to checkin

### DIFF
--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -47,6 +47,8 @@ class Attendee:
     noise_level    = Column(Choice(c.NOISE_LEVEL_OPTS), nullable=True)
     camping_type   = Column(Choice(c.CAMPING_TYPE_OPTS), nullable=True)
     purchased_food = Column(Boolean, default=False)
+    license_plate  = Column(UnicodeText, default='')
+    site_number    = Column(UnicodeText, default='')
 
     @cost_property
     def food_cost(self):

--- a/magstock/site_sections/magstock.py
+++ b/magstock/site_sections/magstock.py
@@ -41,3 +41,11 @@ class Root:
 
     def food_purchases(self, session):
         return {'attendees': session.food_purchasers().order_by(Attendee.full_name).all()}
+
+    @ajax
+    def set_extra_checkin_fields(self, session, id, site_number, license_plate):
+        attendee = session.attendee(id)
+        attendee.site_number = site_number
+        attendee.license_plate = license_plate
+        session.commit()
+        return {'message': 'success'}

--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -117,4 +117,29 @@
             <textarea name="coming_with" class="form-control" placeholder="Full legal names of everyone in your group">{{ attendee.coming_with }}</textarea>
         </div>
     </div>
+
+    {% if c.PAGE_PATH == '/registration/form' %}
+        <div class="form-group" id="allergies">
+            <label class="col-sm-2 control-label optional-field">Site Number</label>
+            <div class="col-sm-6">
+                <input type="text" class="form-control" name="site_number" value="{{ attendee.site_number }}" placeholder="Admin-only field" />
+            </div>
+        </div>
+
+        <div class="form-group" id="allergies">
+            <label class="col-sm-2 control-label optional-field">License Plate</label>
+            <div class="col-sm-6">
+                <input type="text" class="form-control" name="license_plate" value="{{ attendee.license_plate }}" placeholder="Admin-only field" />
+            </div>
+        </div>
+    {% endif %}
 </div>
+
+{% if c.AT_THE_CON and c.PAGE_PATH == '/preregistration/form' %}
+    <script>
+        $('.panel')
+            .empty()
+            .append('<h2 align="center">Preregistration is Closed</h2>')
+            .append('MAGStock preregistration is closed, but you can register at the door <a href="../registration/register">here</a>.');
+    </script>
+{% endif %}

--- a/magstock/templates/registration/checkin.html
+++ b/magstock/templates/registration/checkin.html
@@ -1,0 +1,154 @@
+<script type="text/javascript">
+    $(function() {
+        $('.dialog-form').dialog({ autoOpen: false });
+
+        $('.attendee-checkin').button().on('click', function () {
+            var attendee_id = $(this).attr('data-attendeeid');
+            var dialog = $('#' + attendee_id).dialog({
+                autoOpen: false,
+                height: 450,
+                width: 500,
+                modal: true,
+                buttons: [{
+                    text: 'Save & Check In',
+                    click: function() {
+                        check_in(attendee_id);
+                        dialog.dialog('close');
+                    }
+                }, {
+                    text: 'Cancel',
+                    click: function () {
+                        dialog.dialog('close');
+                    }
+                }],
+                // FIXME: OMG TERRIBLE POSITION HAX
+                open: function () {
+                  $('.ui-dialog').css('position', 'fixed')
+                    .css('top', '5%')
+                    .css('left', '33%');
+                }
+            });
+            dialog.find('input.num').keypress(function (event) {
+                if (event.keyCode === 13) {  // Enter key
+                    event.preventDefault();
+                    dialog.dialog('close');
+                }
+            });
+            dialog.dialog('open');
+            dialog.dialog('option', 'position', {at: 'center', of: window});
+        });
+    });
+
+    var check_in = function (id) {
+        if ($('#age_' + id).val() == {{ c.AGE_UNKNOWN }}) {
+            alert('You may not check someone in without confirming their age.');
+            return;
+        }
+        $.post('../magstock/set_extra_checkin_fields', {
+            id: id,
+            csrf_token: csrf_token,
+            site_number: $('#site_' + id).val(),
+            license_plate: $('#license_' + id).val()
+        }, function (json) {
+            $.post('check_in', {
+                id: id,
+                csrf_token: csrf_token,
+                age_group:  $('#age_' + id).val(),
+                badge_num:  $('#num_' + id).val(),
+                group: $('#group_' + id).val() || ''
+            }, function (json) {
+                var message = json.message;
+                if (json.success) {
+                    message += ' &nbsp; <a href="#" onClick="undoCheckin(\'' + id + '\', ' + json.pre_badge + ') ; return false">Undo</a>';
+                    $('#paid_' + id).html(json.paid);
+                    $('#cin_' + id).html(json.checked_in);
+                    $('#age_' + id).parent().html(json.age_group);
+                    $('#num_' + id).parent().html(json.badge);
+                }
+                toastr.info(message);
+                if (json.increment) {
+                    $('#checkin_count').html(1 + parseInt($("#checkin_count").html()));
+                }
+            }, 'json');
+        }, 'json');
+    };
+
+    var undoCheckin = function (id, pre_badge) {
+        $.post('undo_checkin', {id: id, csrf_token: csrf_token, pre_badge: pre_badge}, function(s) {
+            var sep = location.href.indexOf('?') === -1 ? '?' : '&';
+            location.href += sep + 'message=' + encodeURIComponent(s);
+        });
+    };
+</script>
+{% for attendee in attendees %}
+    {% if c.AT_THE_CON and attendee.paid != c.NOT_PAID and not attendee.is_unassigned and not attendee.checked_in %}
+        <div class="dialog-form" id="{{ attendee.id }}" title="Quick Check-In">
+            <table>
+                <tr>
+                    <td><strong>Name:</strong></td>
+                    <td>{{ attendee.full_name }}</td>
+                </tr>
+                <tr>
+                    <td><strong>Badge Type:</strong></td>
+                    <td>{{ attendee.badge_type_label }}
+                        {% if attendee.ribbon != c.NO_RIBBON %}
+                            ({{ attendee.ribbon_label }})
+                        {% endif %}
+                    </td>
+                </tr>
+                {% if c.NUMBERED_BADGES %}
+                    <tr>
+                        <td><strong>Badge Number:</strong></td>
+                        <td>
+                            {% if attendee.badge_num %}
+                                {{ attendee.badge_num }}
+                                <input type="hidden" id="num_{{ attendee.id }}" value="{{ attendee.badge_num }}" />
+                            {% else %}
+                                # <input class="num" id="num_{{ attendee.id }}" type="text" size="5" />
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <td><strong>Age Group:</strong></td>
+                    <td>
+                        <select id="age_{{ attendee.id }}">
+                            {% options c.AGE_GROUP_OPTS attendee.age_group %}
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong>Site Number</strong></td>
+                    <td><input type="text" id="site_{{ attendee.id }}" value="{{ attendee.site_number }}" /></td>
+                </tr>
+                <tr>
+                    <td><strong>License Plate</strong></td>
+                    <td><input type="text" id="license_{{ attendee.id }}" value="{{ attendee.licence_plate }}" /></td>
+                </tr>
+                {% if attendee.paid == c.PAID_BY_GROUP and not attendee.group_id %}
+                    <tr>
+                        <td><strong>Group:</strong></td>
+                        <td>
+                            <select id="group_{{ attendee.id }}">
+                                <option value="">No Group</option>
+                                {% options groups attendee.group_id %}
+                            </select>
+                        </td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <td><strong>Email:</strong></td>
+                    <td>{{ attendee.email }}</td>
+                </tr>
+                <tr>
+                    <td><strong>Zipcode:</strong></td>
+                    <td>{{ attendee.zip_code }}</td>
+                </tr>
+                <tr>
+                    <td><strong>Emergency Contact:</strong></td>
+                    <td>{{ attendee.ec_phone }}</td>
+                </tr>
+            </table>
+        </div>
+    {% endif %}
+{% endfor %}

--- a/magstock/templates/registration/new.html
+++ b/magstock/templates/registration/new.html
@@ -1,0 +1,211 @@
+{% extends "base-admin.html" %}
+{% block title %}Recent At-the-Door Registrations{% endblock %}
+{% block content %}
+
+<link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
+
+{% if checked_in %}
+    <a href="undo_new_checkin?id={{ checked_in }}">Undo</a>
+{% endif %}
+<script src="../static/js/servertimecheck.js" type="text/javascript"></script>
+
+<script type="text/javascript">
+    // automatically log out after 15 minutes of inactivity
+    setTimeout(function () {
+        window.location = "../accounts/logout";
+    }, 900000);
+    
+    var UNASSIGNED = {{ unassigned|jsonize }};
+    var groupChosen = function(group) {
+        var $group = $(group);
+        var $link = $group.prev('a');
+        var $badgeNum = $group.nextAll(':text');
+        if ($group.val() === '') {
+            $link.hide();
+        } else {
+            $link.show().attr('href', '../groups/form?id=' + $group.val());
+            $group.parents('tr').find(':submit').removeAttr('disabled');
+        }
+        $badgeNum.focus();
+    };
+    
+    var toggleMarkButton = function (dropdown) {
+        var $button = $(dropdown).parent().find(':submit');
+        if ($(dropdown).val()) {
+            $button.removeAttr('disabled');
+        } else {
+            $button.attr('disabled', 'disabled');
+        }
+    };
+    $(function () {
+        $('table.list select[name=payment_method]').each(function (i, dropdown) {
+            toggleMarkButton(dropdown);
+        });
+    });
+    
+    var recordFee = function() {
+        $.post('record_sale', {
+                id:             'None',
+                what:           $('#what_select').val() || $('#what_text').val() || '',
+                cash:           $('#store_cash').val(),
+                badge_num:      $('#badge_num').val() || undefined,
+                payment_method: $('#payment_method').val(),
+                mpoints:        0,
+                csrf_token:     csrf_token
+            }, function(json) {
+                toastr.remove();
+                if (!json.success) {
+                    toastr.error(json.message);
+                } else {
+                    $('#badge_num').val('');
+                    toastr.info(json.message);
+                    $('.toast-message').append(' &nbsp; <a href="#" onClick="undoSale(\'' + json.id + '\') ; return false">Undo</a>');
+                }
+            }, 'json');
+    };
+    var undoSale = function(id) {
+        $.post('undo_sale', {id: id, csrf_token: csrf_token}, function(message) {
+            toastr.remove();
+            toastr.info(message);
+        });
+    };
+    var showOrHideWhatText = function(page_loading) {
+        $('#store_mpoints').val('0');
+        if( $('#what_select').val() == '' ) {
+            $('#what_text').show().focus();
+            $('#store_cash').val('');
+        }
+        else {
+            var prices = {{ c.FEE_PRICES|safe }};
+            $('#what_text').val('').hide();
+            $('#store_cash').val( prices[$('#what_select').val()] );
+            if( !page_loading )
+                $('#store_amount').focus();
+        }
+    };
+    $(showOrHideWhatText);
+
+    var submitExtraFields = function (id, button) {
+        var $row = $(button).parents('tr');
+        $.post('../magstock/set_extra_checkin_fields', {
+            id: id,
+            csrf_token: csrf_token,
+            site_number: $row.find('.site-number').val(),
+            license_plate: $row.find('.license-plate').val()
+        }, function (json) {
+            button.form.submit();
+        }, 'json');
+        return false;
+    };
+</script>
+
+<h2> {% if not show_all %}Recent{% endif %} At-the-Door Registrations </h2>
+
+<div style="text-align:center">
+    {% if show_all %}
+        <a href="new">Click Here</a> to see only recent at-the-door registrations
+    {% else %}
+        <a href="new?show_all=true">Click Here</a> to see all at-the-door registrations instead of only recent ones
+    {% endif %}
+    <br/> <a href="index">Click Here</a> to view the preregistered and checked in attendee list
+    <br/> <a href="arbitrary_charge_form">Click Here</a> to create arbitrary credit card charges if Square stops working
+</div>
+
+<div style="text-align:center; font-weight:bold; {% if remaining_badges < 50 %} font-size:18pt; {% endif %}">
+    <br/> Badges remaining: <font color="red">{{ remaining_badges }}</font>
+</div>
+
+<div id="transactions" style="text-align:center ; margin-top:5px ; padding:10px ; background:lightgray ; width:100%">
+    <table style="width:100%"> <tr>
+        <td>Record a Fee: </td>
+        <td>
+            Payment Method:
+            <select id="payment_method">
+                {% options c.FEE_PAYMENT_METHOD_OPTS %}
+            </select>
+        </td>
+        {% if c.NUMBERED_BADGES %}
+            <td>Badge Num: <input type="text" id="badge_num" size="4" class="focus" /></td>
+        {% endif %}
+        <td>
+            <select id="what_select" onChange="showOrHideWhatText()">
+                {% options c.FEE_ITEM_NAMES %}
+                <option value="">Other...</option>
+            </select>
+            <input type="text" id="what_text" size="20" maxlength="50" />
+        </td>
+        <td> Money: $<input type="text" id="store_cash" size="2" /> </td>
+        <td> <input type="submit" id="record_sale" value="Record Fee" onClick="recordFee()" /> </td>
+    </tr> </table>
+</div>
+
+<br/>
+
+<table class="list">
+<tr class="header">
+    <td align="left">Name</td>
+    <td>Badge Type</td>
+    <td>Age</td>
+    <td>Cost</td>
+    <td>Paid</td>
+    <td>Site Number</td>
+    <td>License Plate</td>
+    {% if c.NUMBERED_BADGES %}
+        <td>Badge</td>
+    {% endif %}
+    <td></td>
+</tr>
+{% for attendee in recent %}
+    <tr>
+        <td align="left">
+            <a href="form?return_to=new%3f&id={{ attendee.id }}">{{ attendee.full_name }}</a>
+            {% if attendee.banned %}
+                <div style="color:red">This attendee's name matches the name of a banned person.  Please get a department head to handle this.</div>
+            {% endif %}
+        </td>
+        <td>{{ attendee.badge_type_label }}</td>
+        <td>{{ attendee.age_group_conf.desc }}</td>
+        <td>${{ attendee.total_cost }}</td>
+        <td>
+            {% if attendee.paid == c.HAS_PAID %}
+                paid
+            {% elif attendee.paid == c.PAID_BY_GROUP %}
+                paid by group
+            {% else %}
+                <form method="post" action="mark_as_paid">
+                {% csrf_token %}
+                <input type="hidden" name="id" value="{{ attendee.id }}" />
+                <select name="payment_method" onChange="toggleMarkButton(this)">
+                    <option value="">Payment Method</option>
+                    {% options c.NEW_REG_PAYMENT_METHOD_OPTS attendee.payment_method %}
+                </select>
+                <input type="submit" disabled="disabled" value="Mark as Paid" />
+                </form>
+            {% endif %}
+        </td>
+        <td><input type="text" size="4" class="site-number" placeholder="Site" value="{{ attendee.site_number }}" /></td>
+        <td><input type="text" size="8" class="license-plate" placeholder="License" value="{{ attendee.license_plate }}" /></td>
+        {% if attendee.paid == c.PAID_BY_GROUP %}
+            <td colspan="2">
+                check in group badges <a href="index?search_text={{ attendee.id }}">here</a>
+            </td>
+        {% else %}
+            <form method="post" action="new_checkin">
+            {% if c.NUMBERED_BADGES %}
+                <td>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <input type="text" name="badge_num" size="4" />
+                </td>
+            {% endif %}
+            <td>
+                {% csrf_token %}
+                <input type="hidden" name="id" value="{{ attendee.id }}" />
+                <input type="submit" value="Check In" {% if attendee.paid == c.NOT_PAID %}disabled{% endif %} onClick="return submitExtraFields('{{ attendee.id }}', this)" />
+            </td>
+            </form>
+        {% endif %}
+    </tr>
+{% endfor %}
+</table>
+
+{% endblock %}


### PR DESCRIPTION
In the long run we'll need a better way than this - what I did here was kludgy because doing it right was more effort than I have time for at the moment,

The way I did this was as follows:
* I added two new database columns (which I manually added to the dbs on the staging and production server, since we don't have automatic migrations yet).
* I added an ajax action to the ``magstock`` site section which sets the extra fields.
* I overrode the two templates where people get checked in; because there's not an elegant way in place to do this, I just overrode the templates in their entirety by copying the contents of the files and adding some Javascript which submits the extra fields to the new ajax action.

So yeah, this is kind of dumb, but I tested it out and it works great, and we didn't need to modify core Uber.  Obviously this isn't how we'll want to do this stuff in the future, but we'll make it more flexible next time :)

While I was at it, I also made it so that the main prereg form just says that prereg is closed and links you to the at-the-door reg page.