### PR TITLE
Add Food field to check-in page

### DIFF
--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -57,7 +57,7 @@ class Attendee:
     @property
     def auto_food(self):
         return self.badge_type in [c.STAFF_BADGE, c.GUEST_BADGE]
-        
+
     @property
     def gets_food(self):
         return self.auto_food or self.purchased_food

--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -57,6 +57,10 @@ class Attendee:
     @property
     def auto_food(self):
         return self.badge_type in [c.STAFF_BADGE, c.GUEST_BADGE]
+        
+    @property
+    def gets_food(self):
+        return self.auto_food or self.purchased_food
 
     @presave_adjustment
     def roughing_it(self):

--- a/magstock/templates/registration/checkin.html
+++ b/magstock/templates/registration/checkin.html
@@ -118,6 +118,10 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><strong>Food?</strong></td>
+                    <td>{{ attendee.gets_food }}</td>
+                </tr>
+                <tr>
                     <td><strong>Site Number</strong></td>
                     <td><input type="text" id="site_{{ attendee.id }}" value="{{ attendee.site_number }}" /></td>
                 </tr>


### PR DESCRIPTION
Emergency fix for on-site Magstock registration - they need to see if someone is getting food while checking that person in.