### PR TITLE
Hide kick-in levels

### DIFF
--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -41,6 +41,9 @@
         if ($.field('badge_printed_name')) {
             $.field('badge_printed_name').parents('.form-group').remove();
         }
+        {% if c.PAGE_PATH != '/registration/form' %}
+            $.field('amount_extra').parents('.form-group').hide();
+        {% endif %}
     });
 </script>
 


### PR DESCRIPTION
Fixes https://github.com/magfest/magstock/issues/28. Avoids hiding the kick-in levels on the admin page because there's no badge options on that page.