### PR TITLE
Fix JS to only change badge buttons when appropriate

### DIFF
--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -1,17 +1,24 @@
 
 <script type="text/javascript">
     if (window.BADGE_TYPES) {
-        BADGE_TYPES.options[0].description = 'Includes three day admission and campground fees';
-        if (BADGE_TYPES.options[2]) {
-            BADGE_TYPES.options[2].description = 'T-shirt level plus additional swag. (Available until {{ c.SUPPORTER_DEADLINE|datetime:'%b %d' }}. Limited quantities.)';
+        for (var i = 0; i < _(BADGE_TYPES.options).size(); i++) {
+            switch (BADGE_TYPES.options[i].extra) {
+                case 0:
+                    BADGE_TYPES.options[i].description = 'Includes three day admission and campground fees.';
+                    break;
+                case {{ c.SHIRT_LEVEL }}:
+                    BADGE_TYPES.options[i] = {
+                        title: 'Add a T-Shirt',
+                        description: 'Attendee level plus a MAGStock-themed t-shirt.',
+                        extra: {{ c.SHIRT_LEVEL }}
+                    };
+                    break;
+                case {{ c.SUPPORTER_LEVEL }}:
+                    BADGE_TYPES.options[i].description = 'T-shirt level plus additional swag. (Available until {{ c.SUPPORTER_DEADLINE|datetime:'%b %d' }}. Limited quantities.)';
+                    break;
+            }
         }
-        {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS %}
-            BADGE_TYPES.options[1] = {
-                title: 'Add a T-Shirt',
-                description: 'Attendee level plus a MAGStock-themed t-shirt',
-                extra: {{ c.SHIRT_LEVEL }}
-            };
-        {% endif %}
+
         $(function () {
             if ($.field('amount_extra')) {
                 $.field('amount_extra').parents('.form-group').hide();

--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -1,23 +1,23 @@
 
 <script type="text/javascript">
     if (window.BADGE_TYPES) {
-        for (var i = 0; i < _(BADGE_TYPES.options).size(); i++) {
+        $.each(BADGE_TYPES.options, function (i, badgeType) {
             switch (BADGE_TYPES.options[i].extra) {
                 case 0:
-                    BADGE_TYPES.options[i].description = 'Includes three day admission and campground fees.';
+                    $.extend(badgeType, {description: 'Includes three day admission and campground fees.'});
                     break;
                 case {{ c.SHIRT_LEVEL }}:
-                    BADGE_TYPES.options[i] = {
+                    $.extend(badgeType, {
                         title: 'Add a T-Shirt',
                         description: 'Attendee level plus a MAGStock-themed t-shirt.',
                         extra: {{ c.SHIRT_LEVEL }}
-                    };
+                    });
                     break;
                 case {{ c.SUPPORTER_LEVEL }}:
-                    BADGE_TYPES.options[i].description = 'T-shirt level plus additional swag. (Available until {{ c.SUPPORTER_DEADLINE|datetime:'%b %d' }}. Limited quantities.)';
+                    $.extend(badgeType, {description: 'T-shirt level plus additional swag. (Available until {{ c.SUPPORTER_DEADLINE|datetime:'%b %d' }}. Limited quantities.)'});
                     break;
             }
-        }
+        });
 
         $(function () {
             if ($.field('amount_extra')) {


### PR DESCRIPTION
Fixes https://github.com/magfest/magstock/issues/39. The basic problem here was that we had JS in regextra.html that assumed it would be on the preregistration form, but we had since added code to remove badge buttons after an attendee kicked in money. The JS then changed the new badge buttons, in some cases making it impossible to upgrade.