### PR TITLE
fix volunteer checklist for magstock

### DIFF
--- a/magstock/templates/signups/shifts_item.html
+++ b/magstock/templates/signups/shifts_item.html
@@ -1,0 +1,13 @@
+{% comment %}Magstock-specific: don't worry about shirt and food prerequisites for Magstock{% endcomment%}
+
+{% if attendee.takes_shifts %}
+    <li>
+        {% checked_if attendee.shifts %}
+        {% if not attendee.placeholder %}
+            <a href="shifts">Sign up</a>
+        {% else %}
+            Sign up
+        {% endif %}
+        for shifts.
+    </li>
+{% endif %}


### PR DESCRIPTION
- override shifts_item.html to have prerequisite only be placeholder, nothing else
- set other steps in volunteer checklist to empty strings to disable them for magstock

merge with https://github.com/magfest/production-config/pull/49
fixes #77 