### PR TITLE
Update price prereg_closed.html

### DIFF
--- a/magstock/templates/static_views/prereg_closed.html
+++ b/magstock/templates/static_views/prereg_closed.html
@@ -2,7 +2,7 @@
     <h2 style='color:red'>{{ c.EVENT_NAME_AND_YEAR }} pre-registration has closed.</h2>
     We'll see everyone {{ c.EVENT_MONTH }} {{ c.EVENT_START_DAY }} - {{ c.EVENT_END_DAY }}.<br/>
     <br/>
-    Full weekend passes will be available at the door for $65. . We do not anticipate selling out tickets, so you should have no problem purchasing a pass at-event, however our meal plans are sold out.
+    Full weekend passes will be available at the door for $70. . We do not anticipate selling out tickets, so you should have no problem purchasing a pass at-event, however our meal plans are sold out.
     <br/>
     Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
 </body></html>


### PR DESCRIPTION
There should be a way to link the ATD price to: 
https://github.com/magfest/production-config/blob/master/event-magstock.yaml
uber::config::badge_prices:
  attendee:
    - { '2016-06-01': 60 }
- { '2016-06-16': 70 }

So we don't have to manually input this value on this field