### PR TITLE
Add link to find tent leader

### DIFF
--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -53,6 +53,9 @@
         if ($.field('badge_printed_name')) {
             $.field('badge_printed_name').parents('.form-group').remove();
         }
+        if ($('#leader_search')) {
+            $('#leader_search').appendTo($.field('coming_with').parents('.form-group'));
+        }
     });
 </script>
 
@@ -157,6 +160,12 @@
                 <input type="text" class="form-control" name="license_plate" value="{{ attendee.license_plate }}" placeholder="Admin-only field" />
             </div>
         </div>
+
+        {% if attendee.coming_as == c.TENT_FOLLOWER %}
+            <p id="leader_search" class="help-block col-sm-6">
+                <a href="index?search_text={{ attendee.coming_with }}" target="_blank">Find Tent Leader</a>
+            </p>
+        {% endif %}
     {% endif %}
 </div>
 

--- a/magstock/templates/registration/check_in_form.html
+++ b/magstock/templates/registration/check_in_form.html
@@ -17,5 +17,11 @@
         <td><strong>License Plate</strong></td>
         <td><input type="text" id="license_{{ attendee.id }}" name="license_plate" value="{{ attendee.license_plate }}" /></td>
     </tr>
+    {% if attendee.coming_as == c.TENT_FOLLOWER %}
+        <tr>
+            <td><strong>Tent Leader</strong></td>
+            <td><a href="index?search_text={{ attendee.coming_with }}" target="_blank">Find Tent Leader</a></td>
+        </tr>
+    {% endif %}
     {{ block.super }}
 {% endblock checkin_fields %}


### PR DESCRIPTION
Fixes https://github.com/magfest/magstock/issues/70 for this year by adding a link to search for someone's tent leader, if they listed one. In the future, we'll need to capture better data.