### PR TITLE
Add casting for Magstock only

### DIFF
--- a/magstock/site_sections/magstock.py
+++ b/magstock/site_sections/magstock.py
@@ -1,4 +1,5 @@
 from uber.common import *
+from sqlalchemy.sql.expression import cast
 
 
 @all_renderable(c.PEOPLE)
@@ -57,7 +58,7 @@ class Root:
         campsite_assignments = []
         for site_id, site_name in c.CAMPSITE_OPTS:
             campsite_assignments.append({'site_name': site_name, 'attendees':
-                session.query(Attendee).filter(Attendee.site_number == site_id).all()})
+                session.query(Attendee).filter(cast(site_id, sqlalchemy.String) == Attendee.site_number).all()})
 
         return {
             'campsite_assignments': campsite_assignments


### PR DESCRIPTION
The only reason we need casting is because we messed up the DB migration - the column should not be of VARCHAR type. So we're importing cast inside the Magstock plugin only.