### PR TITLE
Count paid AND free food against food stocks

### DIFF
--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -22,7 +22,7 @@ class ExtraConfig:
     @property
     def FOOD_COUNT(self):
         with Session() as session:
-            return session.food_purchasers().count()
+            return session.food_consumers().count()
 
     @property
     def PREREG_DONATION_OPTS(self):


### PR DESCRIPTION
MAGStock's team was expecting that food sales would close as soon as total food consumers hit 150, but we were only counting food purchasers against the stock. This fixes that.