### PR TITLE
Remove base-admin.html

### DIFF
--- a/magstock/templates/magstock/campsite_assignments.html
+++ b/magstock/templates/magstock/campsite_assignments.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Magstock Campsites{% endblock %}
 {% block content %}
 

--- a/magstock/templates/magstock/food_consumers.html
+++ b/magstock/templates/magstock/food_consumers.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Magstock Food Report{% endblock %}
 {% block content %}
 

--- a/magstock/templates/magstock/grouped.html
+++ b/magstock/templates/magstock/grouped.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Parties{% endblock %}
 {% block content %}
 

--- a/magstock/templates/magstock/parking.html
+++ b/magstock/templates/magstock/parking.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Magstock Vehicles{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.