### PR TITLE
Move license plate field to prereg form

### DIFF
--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -77,7 +77,7 @@ class Attendee:
     noise_level = Column(Choice(c.NOISE_LEVEL_OPTS), nullable=True)
     camping_type = Column(Choice(c.CAMPING_TYPE_OPTS), nullable=True)
     purchased_food = Column(Boolean, default=False)
-    license_plate = Column(UnicodeText, default='', admin_only=True)
+    license_plate = Column(UnicodeText, default='')
     site_number = Column(Choice(c.CAMPSITE_OPTS), nullable=True, admin_only=True)
 
     @cost_property

--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -175,6 +175,16 @@
         </div>
     </div>
 
+    <div class="form-group">
+      <label class="col-sm-3 control-label optional-field">License Plate #</label>
+      <div class="col-sm-6">
+        <input type="text" class="form-control" name="license_plate" value="{{ attendee.license_plate }}" placeholder="XXX-XXXX" />
+        <p class="help-block">
+          Get through registration faster on-site! If you don't know which vehicle you'll be using, you can come back and update this later.
+        </p>
+      </div>
+    </div>
+
     {% if c.PAGE_PATH == '/registration/form' %}
         <div class="form-group">
             <label class="col-sm-3 control-label optional-field">Site Number</label>
@@ -183,13 +193,6 @@
                     <option value="">Choose a campsite, if applicable</option>
                     {{ options(c.CAMPSITE_OPTS, attendee.site_number) }}
                 </select>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <label class="col-sm-3 control-label optional-field">License Plate</label>
-            <div class="col-sm-6">
-                <input type="text" class="form-control" name="license_plate" value="{{ attendee.license_plate }}" placeholder="Admin-only field" />
             </div>
         </div>
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-429. We're only collecting the license plate number right now as having the extra fields will clutter up the pre-reg page (per @bitbyt3r)

![image](https://user-images.githubusercontent.com/7198215/55450512-5ffaa900-559d-11e9-9964-5afee11a8ab9.png)