### PR TITLE
Add shirt size and gets_food for MAGStock check-in

### DIFF
--- a/magstock/__init__.py
+++ b/magstock/__init__.py
@@ -5,6 +5,7 @@ from os.path import join
 from residue import CoerceUTF8 as UnicodeText
 from sideboard.lib import parse_config
 from sqlalchemy.types import Boolean, Date
+from uber.api import AttendeeLookup
 from uber.config import c, Config
 from uber.decorators import cost_property, prereg_validation, presave_adjustment, validation
 from uber.menu import MenuItem
@@ -30,6 +31,7 @@ c.MENU.append_menu_item(
     ])
 )
 
+AttendeeLookup.fields_full['gets_food'] = True
 
 @Config.mixin
 class ExtraConfig:

--- a/magstock/templates/registration/check_in_form.html
+++ b/magstock/templates/registration/check_in_form.html
@@ -23,9 +23,17 @@
             <td><a href="index?search_text={{ attendee.coming_with }}" target="_blank">Find Tent Leader</a></td>
         </tr>
     {% endif %}
+    {% if attendee.amount_extra %}
     <tr>
         <td><strong>Kick-in Level</strong></td>
         <td>{{ attendee.amount_extra_label }}</td>
     </tr>
+    {% endif %}
+    {% if attendee.amount_extra >= c.SHIRT_LEVEL %}
+    <tr>
+      <td><strong>T-Shirt Size</strong></td>
+      <td>{{ attendee.shirt_label or 'Not Selected' }}</td>
+    </tr>
+    {% endif %}
     {{ super() }}
 {% endblock checkin_fields %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-170. We actually already collected the License plate during check-in, so this just adds the shirt size -- the 'got merch' checkbox is handled in the main plugin via a feature flag.

It also adds the `get_food` property to the full lookup for API calls, which is thankfully exactly as easy as I'd hoped it would be.