### PR TITLE
Fix positioning of extra fields if there are no merch tiers left

### DIFF
--- a/magstock/templates/regextra.html
+++ b/magstock/templates/regextra.html
@@ -79,8 +79,8 @@
             $('#no-early-checkin').insertBefore('#reg-types');
             $.field('acknowledged_checkin_policy').attr('form', 'prereg-form');
         }
-        if ($('#food').size() && $.field('amount_extra')) {
-            $('#food').insertAfter($.field('amount_extra').parents('.form-group'));
+        if ($('#food').size()) {
+            $('#food').insertAfter($('.extra-row').last().parents('.form-group'));
         }
         $('#camping-types').insertAfter($('#food'));
         $('#extra-fields').insertBefore($.field('staffing').parents('.form-group'));


### PR DESCRIPTION
The amount_extra field doesn't exist when merch is sold out, so these fields were getting moved to the bottom of the page. This should fix that.