### PR TITLE
Add summary page for MAGStock add-ons

### DIFF
--- a/magstock/site_sections/magstock.py
+++ b/magstock/site_sections/magstock.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from sqlalchemy import func
 
 from uber.config import c
 from uber.decorators import ajax, all_renderable
@@ -75,3 +76,10 @@ class Root:
         attendee.license_plate = license_plate
         session.commit()
         return {'message': 'success'}
+    
+    def addons(self, session):
+        return {
+            'all_cabins_stock': sum([int(val) for key, val in c.CABIN_TYPE_STOCKS.items()]),
+            'brunch_ticket_count': session.valid_attendees().with_entities(func.sum(Attendee.brunch_tickets)).scalar(),
+            'dinner_ticket_count': session.valid_attendees().with_entities(func.sum(Attendee.dinner_tickets)).scalar(),
+        }

--- a/magstock/templates/magstock/addons.html
+++ b/magstock/templates/magstock/addons.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Parties{% endblock %}
+{% block content %}
+
+<h2 class="center">MAGStock Add-Ons Summary</h2>
+
+<div class="panel panel-default">
+    <div class="panel-heading">Camping Type and Cabins</div>
+    <div class="panel-body">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <td colspan="2">Item Name</td>
+                    <td>Price</td>
+                    <td># Stock</td>
+                    <td># Bought</td>
+                    <td># Left</td>
+                    <td>Total $</td>
+                </tr>
+            </thead>
+            <tbody>
+                {% for key, val in c.CAMPING_TYPES.items() %}
+                <tr>
+                    <td colspan="2">{{ val }}</td>
+                    <td>{% if key != c.CABIN %}{{ c.CAMPING_TYPE_PRICES[key]|format_currency }}{% endif %}</td>
+                    <td>{% if key == c.CABIN %}{{ all_cabins_stock }}{% else %}Unlimited{% endif %}</td>
+                    <td>{{ c.CAMPING_TYPES_BOUGHT[key] }}</td>
+                    <td>{% if key == c.CABIN %}{{ all_cabins_stock - c.CAMPING_TYPES_BOUGHT[key] }}{% else %}N/A{% endif %}</td>
+                    <td>{% if key == c.CABIN %}{{ c.CABIN_TOTAL|format_currency }}{% else %}{{ (c.CAMPING_TYPES_BOUGHT[key] * c.CAMPING_TYPE_PRICES[key])|format_currency }}{% endif %}</td>
+                </tr>
+                    {% if key == c.CABIN %}
+                        {% for key, val in c.CABIN_AVAILABILITY_MATRIX.items() %}
+                        <tr>
+                            <td></td>
+                            <td>{{ c.CABIN_TYPES[key] }}</td>
+                            <td>{{ c.CABIN_TYPE_PRICES[key]|format_currency }}</td>
+                            <td>{{ c.CABIN_TYPE_STOCKS[key] }}</td>
+                            <td>{{ c.CABIN_TYPE_STOCKS[key]|int - val }}</td>
+                            <td>{{ val }}</td>
+                            <td>{{ c.CABIN_TOTAL|format_currency }}</td>
+                        </tr>
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="panel panel-default">
+    <div class="panel-heading">Meal Tickets</div>
+    <div class="panel-body">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <td>Item Name</td>
+                    <td>Price</td>
+                    <td># Bought</td>
+                    <td>Total $</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Brunch Ticket</td>
+                    <td>{{ c.FOOD_PRICE|format_currency }}</td>
+                    <td>{{ brunch_ticket_count }}</td>
+                    <td>{{ (brunch_ticket_count * c.FOOD_PRICE)|format_currency }}</td>
+                </tr>
+                <tr>
+                    <td>Dinner Ticket</td>
+                    <td>{{ c.FOOD_PRICE|format_currency }}</td>
+                    <td>{{ dinner_ticket_count }}</td>
+                    <td>{{ (dinner_ticket_count * c.FOOD_PRICE)|format_currency }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This just covers MAGStock add-ons out of concern for timeliness, but in the near-ish future we should probably build similar pages for preordered merch, extra donations, etc